### PR TITLE
Fix scope editing

### DIFF
--- a/Editor/Halodi/PackageRegistry/RegistryManagerController.cs
+++ b/Editor/Halodi/PackageRegistry/RegistryManagerController.cs
@@ -73,6 +73,14 @@ namespace Halodi.PackageRegistry
             return registry;
         }
 
+        private void UpdateScope(ScopedRegistry registry, JToken registryElement) {
+            JArray scopes = new JArray();
+            foreach (var scope in registry.scopes)
+            {
+                scopes.Add(scope);
+            }
+            registryElement["scopes"] = scopes;
+        }
 
         private JToken GetOrCreateScopedRegistry(ScopedRegistry registry, JObject manifestJSON)
         {
@@ -91,6 +99,7 @@ namespace Halodi.PackageRegistry
 
                     if ( String.Equals(JRegistryElement["name"].ToString(), registry.name) && String.Equals(JRegistryElement["url"].ToString(), registry.url))
                     {
+                        UpdateScope(registry, JRegistryElement);
                         return JRegistryElement;
                     };
                 }
@@ -99,13 +108,7 @@ namespace Halodi.PackageRegistry
             JObject JRegistry = new JObject();
             JRegistry["name"] = registry.name;
             JRegistry["url"] = registry.url;
-            JArray scopes = new JArray();
-            foreach (var scope in registry.scopes)
-            {
-                scopes.Add(scope);
-            }
-
-            JRegistry["scopes"] = scopes;
+            UpdateScope(registry, JRegistry);
             Jregistries.Add(JRegistry);
 
             return JRegistry;

--- a/Editor/Halodi/PackageRegistry/ScopedRegistryEditorView.cs
+++ b/Editor/Halodi/PackageRegistry/ScopedRegistryEditorView.cs
@@ -73,7 +73,10 @@ namespace Halodi.PackageRegistry
 
                 string scope = String.Join(",", registry.scopes);
                 scope = EditorGUILayout.TextField("Scope: ", scope);
-                registry.scopes = scope.Split(',');
+                var splitScopes = scope.Split(new char[] {','}, StringSplitOptions.RemoveEmptyEntries);
+                for(int i = 0; i < splitScopes.Length; i++)
+                    splitScopes[i] = splitScopes[i].Trim();
+                registry.scopes = splitScopes;
 
 
                 registry.auth = EditorGUILayout.Toggle("Always auth: ", registry.auth);


### PR DESCRIPTION
There was a slight bug, editing scopes wasn't working.
Also, sanitized the string inputs a bit (since I often type "com.myscope, com.myscope2"), now trimming the strings and ignoring empty entries (e.g. "com.myscope,").