### PR TITLE
Add author

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,10 @@
   "type": "tool",
   "samples": [],
   "description": "Simple tool to manage scoped registries and NPM credentials.",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Halodi",
+    "email": "jesper@halodi.com",
+    "url": "https://halodi.com"
+  }
 }


### PR DESCRIPTION
The author shows as category header in PackMan on current 2019.4 and all 2020+.
Before this PR, it just read "Other".

![image](https://user-images.githubusercontent.com/2693840/95865989-9d7dec00-0d67-11eb-840b-71d339624412.png)