### PR TITLE
Update UpgradePackagesManager.cs

### DIFF
--- a/Editor/Halodi/PackageRegistry/Core/UpgradePackagesManager.cs
+++ b/Editor/Halodi/PackageRegistry/Core/UpgradePackagesManager.cs
@@ -63,7 +63,7 @@ namespace Halodi.PackageRegistry.Core
                     UpgradeablePackages.Add(info);
                 }
             }
-            catch(System.Exception e)
+            catch(System.Exception)
             {
                 Debug.LogError("Invalid version for package " + info.displayName + ". Current: " + info.version + ", Latest: " + GetLatestVersion(info));
             }


### PR DESCRIPTION
Removed warning about unused variable.

We're using ` -warnaserror+` in our project and this prevents us from passing our build tests