### PR TITLE
[UX] Credentials window improvements

### DIFF
--- a/Editor/Halodi/PackageRegistry/NPM/NPMLogin.cs
+++ b/Editor/Halodi/PackageRegistry/NPM/NPMLogin.cs
@@ -31,10 +31,9 @@ namespace Halodi.PackageRegistry.NPM
         }
     }
 
-
+    
     public class NPMLogin
     {
-
         internal static string UrlCombine(string start, string more)
         {
             if (string.IsNullOrEmpty(start))
@@ -62,18 +61,13 @@ namespace Halodi.PackageRegistry.NPM
                 client.Headers.Add(HttpRequestHeader.Accept, "application/json");
                 client.Headers.Add(HttpRequestHeader.ContentType, "application/json");
                 client.Headers.Add(HttpRequestHeader.Authorization, "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes(user + ":" + password)));
-
-
-
+                
                 NPMLoginRequest request = new NPMLoginRequest();
                 request.name = user;
                 request.password = password;
-
-
-
+                
                 string requestString = JsonUtility.ToJson(request);
-
-
+                
                 try
                 {
                     string responseString = client.UploadString(loginUri, WebRequestMethods.Http.Put, requestString);
@@ -82,19 +76,25 @@ namespace Halodi.PackageRegistry.NPM
                 }
                 catch (WebException e)
                 {
-
                     if (e.Response != null)
                     {
-                        Stream receiveStream = e.Response.GetResponseStream();
-                        // Pipes the stream to a higher level stream reader with the required encoding format.
-                        StreamReader readStream = new StreamReader(receiveStream, Encoding.UTF8);
-                        string responseString = readStream.ReadToEnd();
-                        e.Response.Close();
-                        readStream.Close();
+                        try
+                        {
+                            Stream receiveStream = e.Response.GetResponseStream();
+                            // Pipes the stream to a higher level stream reader with the required encoding format.
+                            StreamReader readStream = new StreamReader(receiveStream, Encoding.UTF8);
+                            string responseString = readStream.ReadToEnd();
+                            e.Response.Close();
+                            readStream.Close();
 
-                        return JsonUtility.FromJson<NPMResponse>(responseString);
-
-
+                            return JsonUtility.FromJson<NPMResponse>(responseString);
+                        }
+                        catch (Exception e2)
+                        {
+                            NPMResponse response = new NPMResponse();
+                            response.error = e2.Message;
+                            return response;
+                        }
                     }
                     else
                     {

--- a/Editor/Halodi/PackageRegistry/UI/CredentialEditorView.cs
+++ b/Editor/Halodi/PackageRegistry/UI/CredentialEditorView.cs
@@ -68,6 +68,11 @@ namespace Halodi.PackageRegistry.UI
                     EditorGUILayout.LabelField("Edit credential", EditorStyles.whiteLargeLabel);
                     EditorGUILayout.LabelField("Registry URL: " + registry.url);
                 }
+                
+                if(string.IsNullOrEmpty(registry.url))
+                {
+                    EditorGUILayout.HelpBox("Enter the registry URL you want to add authentication for.", MessageType.Warning);
+                }
 
                 registry.auth = EditorGUILayout.Toggle("Always auth", registry.auth);
                 registry.token = EditorGUILayout.TextField("Token", registry.token);
@@ -76,6 +81,11 @@ namespace Halodi.PackageRegistry.UI
 
                 EditorGUI.BeginDisabledGroup(string.IsNullOrEmpty(registry.url));
                 tokenMethod = GetTokenView.CreateGUI(tokenMethod, registry);
+                
+                if (!string.IsNullOrEmpty(registry.url) && string.IsNullOrEmpty(registry.token))
+                {
+                    EditorGUILayout.HelpBox("Select an authentication method and click on \"Get token\"", MessageType.Warning);
+                }
                 
                 EditorGUI.BeginDisabledGroup(string.IsNullOrEmpty(registry.token));
                 EditorGUILayout.Space();
@@ -103,15 +113,6 @@ namespace Halodi.PackageRegistry.UI
                     Close();
                     GUIUtility.ExitGUI();
                 }
-
-                if(string.IsNullOrEmpty(registry.url))
-                {
-                    EditorGUILayout.HelpBox("Enter the registry URL you want to add authentication for.", MessageType.Warning);
-                }
-                else if (string.IsNullOrEmpty(registry.token))
-                {
-                    EditorGUILayout.HelpBox("Select an authentication method and click on \"Get token\"", MessageType.Warning);
-                }
                 EditorGUILayout.HelpBox("Tip: Restart Unity to reload credentials after saving.", MessageType.Info);
             }
         }
@@ -124,6 +125,12 @@ namespace Halodi.PackageRegistry.UI
                 credentialManager.Write();
                 Close();
                 GUIUtility.ExitGUI();
+                       
+                // TODO figure out in which cases a restart is actually required
+                if (EditorUtility.DisplayDialog("Unity Editor restart might be required", "The Unity editor might need to be restarted for this change to take effect.", "Restart Now", "Cancel"))
+                {
+                    EditorApplication.OpenProject(Environment.CurrentDirectory);
+                }
             }
             else
             {

--- a/Editor/Halodi/PackageRegistry/UI/CredentialEditorView.cs
+++ b/Editor/Halodi/PackageRegistry/UI/CredentialEditorView.cs
@@ -59,27 +59,26 @@ namespace Halodi.PackageRegistry.UI
 
                 if (createNew)
                 {
-                    EditorGUILayout.LabelField("Add credential ", EditorStyles.whiteLargeLabel);
+                    EditorGUILayout.LabelField("Add credential", EditorStyles.whiteLargeLabel);
 
-                    registry.url = EditorGUILayout.TextField("url: ", registry.url);
+                    registry.url = EditorGUILayout.TextField("Registry URL", registry.url);
                 }
                 else
                 {
                     EditorGUILayout.LabelField("Edit credential", EditorStyles.whiteLargeLabel);
-                    EditorGUILayout.LabelField("url: " + registry.url);
+                    EditorGUILayout.LabelField("Registry URL: " + registry.url);
                 }
 
-                registry.auth = EditorGUILayout.Toggle("Always auth: ", registry.auth);
-                registry.token = EditorGUILayout.TextField("Token: ", registry.token);
+                registry.auth = EditorGUILayout.Toggle("Always auth", registry.auth);
+                registry.token = EditorGUILayout.TextField("Token", registry.token);
 
                 EditorGUILayout.Space();
 
+                EditorGUI.BeginDisabledGroup(string.IsNullOrEmpty(registry.url));
                 tokenMethod = GetTokenView.CreateGUI(tokenMethod, registry);
-
-
+                
+                EditorGUI.BeginDisabledGroup(string.IsNullOrEmpty(registry.token));
                 EditorGUILayout.Space();
-                EditorGUILayout.LabelField("Tip: Restart Unity to reload credentials after saving.");
-
 
                 if (createNew)
                 {
@@ -95,13 +94,25 @@ namespace Halodi.PackageRegistry.UI
                         Save();
                     }
                 }
-
+                
+                EditorGUI.EndDisabledGroup();
+                EditorGUI.EndDisabledGroup();
 
                 if (GUILayout.Button("Cancel"))
                 {
                     Close();
                     GUIUtility.ExitGUI();
                 }
+
+                if(string.IsNullOrEmpty(registry.url))
+                {
+                    EditorGUILayout.HelpBox("Enter the registry URL you want to add authentication for.", MessageType.Warning);
+                }
+                else if (string.IsNullOrEmpty(registry.token))
+                {
+                    EditorGUILayout.HelpBox("Select an authentication method and click on \"Get token\"", MessageType.Warning);
+                }
+                EditorGUILayout.HelpBox("Tip: Restart Unity to reload credentials after saving.", MessageType.Info);
             }
         }
 

--- a/Editor/Halodi/PackageRegistry/UI/CredentialEditorView.cs
+++ b/Editor/Halodi/PackageRegistry/UI/CredentialEditorView.cs
@@ -123,14 +123,16 @@ namespace Halodi.PackageRegistry.UI
             {
                 credentialManager.SetCredential(registry.url, registry.auth, registry.token);
                 credentialManager.Write();
-                Close();
-                GUIUtility.ExitGUI();
-                       
-                // TODO figure out in which cases a restart is actually required
+                
+                // TODO figure out in which cases/Editor versions a restart is actually required,
+                // and where a Client.Resolve() call or PackMan reload is sufficient
                 if (EditorUtility.DisplayDialog("Unity Editor restart might be required", "The Unity editor might need to be restarted for this change to take effect.", "Restart Now", "Cancel"))
                 {
                     EditorApplication.OpenProject(Environment.CurrentDirectory);
                 }
+                
+                Close();
+                GUIUtility.ExitGUI();
             }
             else
             {

--- a/Editor/Halodi/PackageRegistry/UI/CredentialManagerView.cs
+++ b/Editor/Halodi/PackageRegistry/UI/CredentialManagerView.cs
@@ -33,7 +33,6 @@ namespace Halodi.PackageRegistry.UI
 
         void OnGUI()
         {
-
             EditorGUILayout.LabelField("Credentials", EditorStyles.whiteLargeLabel);
             credentialScrollPos = EditorGUILayout.BeginScrollView(credentialScrollPos);
 

--- a/Editor/Halodi/PackageRegistry/UI/GetTokenView.cs
+++ b/Editor/Halodi/PackageRegistry/UI/GetTokenView.cs
@@ -119,6 +119,10 @@ namespace Halodi.PackageRegistry.UI
         private void CloseWindow()
         {
             error = null;
+            foreach (var view in Resources.FindObjectsOfTypeAll<CredentialEditorView>())
+            {
+                view.Repaint();
+            }
             Close();
             GUIUtility.ExitGUI();
         }

--- a/Editor/Halodi/PackageRegistry/UI/RegistryManagerView.cs
+++ b/Editor/Halodi/PackageRegistry/UI/RegistryManagerView.cs
@@ -12,7 +12,11 @@ namespace Halodi.PackageRegistry.UI
         [MenuItem("Packages/Manage scoped registries", false, 21)]
         internal static void ManageRegistries()
         {
+            #if UNITY_2020_1_OR_NEWER
+            SettingsService.OpenProjectSettings("Project/Package Manager");
+            #else
             EditorWindow.GetWindow<RegistryManagerView>(true, "Registry manager", true);
+            #endif
         }
 
         private RegistryManager controller;


### PR DESCRIPTION
This PR improves a number of smaller UX details in the credentials flow.

Notably, help boxes have been added to provide guidance on what data to fill in, and buttons are only enabled when they make sense to press.
Additionally, errors are now logged directly into the GetToken view, instead of closing the view and requiring to reopen it to try again, and the credentials view is repainted upon aquiring a token.

On 2020.1+, scoped registries can be directly edited via Project Settings/Package Manager, so the menu item now forwards to there.

Also fixes #14 by asking for editor restart when adding or changing credentials. This could be improved a bit by investigating on which versions Unity needs to be restarted and when a PackMan resolve or reload suffice.