### PR TITLE
Fixes compatibility to Unity 2018.4 LTS.

### DIFF
--- a/Editor/Halodi/PackageRegistry/Core/UpgradePackagesManager.cs
+++ b/Editor/Halodi/PackageRegistry/Core/UpgradePackagesManager.cs
@@ -19,7 +19,11 @@ namespace Halodi.PackageRegistry.Core
 
         internal UpgradePackagesManager()
         {
+#if UNITY_2019_1_OR_NEWER
             request = Client.List(false, false);
+#else
+            request = Client.List();
+#endif
         }
 
         internal void Update()
@@ -78,6 +82,8 @@ namespace Halodi.PackageRegistry.Core
             else
             {
                 string latest = "";
+                
+#if UNITY_2019_1_OR_NEWER
                 if (string.IsNullOrEmpty(info.versions.verified))
                 {
                     latest = info.versions.latestCompatible;
@@ -86,6 +92,10 @@ namespace Halodi.PackageRegistry.Core
                 {
                     latest = info.versions.verified;
                 }
+#else
+                latest = info.versions.latestCompatible;
+#endif
+                
                 return latest;
             }
         }

--- a/Editor/com.halodi.halodi-unity-package-registry-manager.Editor.asmdef
+++ b/Editor/com.halodi.halodi-unity-package-registry-manager.Editor.asmdef
@@ -1,7 +1,7 @@
 {
     "name": "com.halodi.halodi-unity-package-registry-manager.Editor",
     "references": [
-        "GUID:807287499d1ce5fd6a509eb37593f7da"
+        "Artees.SemanticVersioning"
     ],
     "includePlatforms": [
         "Editor"

--- a/ThirdParty/Unity-SemVer/Artees.UnitySemVer.asmdef
+++ b/ThirdParty/Unity-SemVer/Artees.UnitySemVer.asmdef
@@ -4,7 +4,7 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],


### PR DESCRIPTION
Functionality isn't really tested, but the package compiles again.