### PR TITLE
Add support for `_auth` and `email` field in upm credential

### DIFF
--- a/Editor/Halodi/PackageRegistry/Core/CredentialManager.cs
+++ b/Editor/Halodi/PackageRegistry/Core/CredentialManager.cs
@@ -14,6 +14,8 @@ namespace Halodi.PackageRegistry.Core
     {
         public string url;
         public string token;
+        public string _auth;
+        public string email;
         public bool alwaysAuth;
     }
 
@@ -68,8 +70,14 @@ namespace Halodi.PackageRegistry.Core
                             NPMCredential cred = new NPMCredential();
                             cred.url = registry.Key;
                             TomlTable value = (TomlTable)registry.Value;
-                            cred.token = (string)value["token"];
-                            cred.alwaysAuth = (bool)value["alwaysAuth"];
+                            if (value.TryGetValue(nameof(NPMCredential.token), out var token))
+                                cred.token = (string) token;
+                            if (value.TryGetValue(nameof(NPMCredential._auth), out var _auth))
+                                cred._auth = (string) _auth;
+                            if (value.TryGetValue(nameof(NPMCredential.email), out var email))
+                                cred.email = (string)email;
+                            if (value.TryGetValue(nameof(NPMCredential.alwaysAuth), out var alwaysAuth))
+                                cred.alwaysAuth = (bool)alwaysAuth;
 
                             credentials.Add(cred);
                         }
@@ -89,15 +97,17 @@ namespace Halodi.PackageRegistry.Core
                     credential.token = "";
                 }
 
-                doc.Tables.Add(new TableSyntax(new KeySyntax("npmAuth", credential.url))
-                {
-                    Items =
-                    {
-                        {"token", credential.token},
-                        {"alwaysAuth", credential.alwaysAuth}
-                    }
-                });
+                var table = new TableSyntax(new KeySyntax("npmAuth", credential.url));
 
+                if(!string.IsNullOrEmpty(credential.token))
+                    table.Items.Add(nameof(NPMCredential.token), credential.token);
+                if(!string.IsNullOrEmpty(credential._auth))
+                    table.Items.Add(nameof(NPMCredential._auth), credential._auth);
+                if(!string.IsNullOrEmpty(credential.email))
+                    table.Items.Add(nameof(NPMCredential.email), credential.email);
+                table.Items.Add(nameof(NPMCredential.alwaysAuth), credential.alwaysAuth);
+
+                doc.Tables.Add(table);
             }
 
 
@@ -114,21 +124,25 @@ namespace Halodi.PackageRegistry.Core
             return credentials.FirstOrDefault(x => x.url?.Equals(url, StringComparison.Ordinal) ?? false);
         }
 
-        public void SetCredential(string url, bool alwaysAuth, string token)
+        public void SetCredential(NPMCredential inputCred)
         {
-            if (HasRegistry(url))
+            if (HasRegistry(inputCred.url))
             {
-                var cred = GetCredential(url);
-                cred.url = url;
-                cred.alwaysAuth = alwaysAuth;
-                cred.token = token;
+                var cred = GetCredential(inputCred.url);
+                cred.url = inputCred.url;
+                cred.alwaysAuth = inputCred.alwaysAuth;
+                cred.token = inputCred.token;
+                cred.email = inputCred.email;
+                cred._auth = inputCred._auth;
             }
             else
             {
                 NPMCredential newCred = new NPMCredential();
-                newCred.url = url;
-                newCred.alwaysAuth = alwaysAuth;
-                newCred.token = token;
+                newCred.url = inputCred.url;
+                newCred.alwaysAuth = inputCred.alwaysAuth;
+                newCred.token = inputCred.token;
+                newCred.email = inputCred.email;
+                newCred._auth = inputCred._auth;
 
                 credentials.Add(newCred);
             }

--- a/Editor/Halodi/PackageRegistry/Core/RegistryManager.cs
+++ b/Editor/Halodi/PackageRegistry/Core/RegistryManager.cs
@@ -61,6 +61,8 @@ namespace Halodi.PackageRegistry.Core
                 NPMCredential credential = credentialManager.GetCredential(registry.url);
                 registry.auth = credential.alwaysAuth;
                 registry.token = credential.token;
+                registry._auth = credential._auth;
+                registry.email = credential.email;
             }
 
             return registry;
@@ -129,9 +131,9 @@ namespace Halodi.PackageRegistry.Core
 
             JToken manifestRegistry = GetOrCreateScopedRegistry(registry, manifestJSON);
 
-            if(!string.IsNullOrEmpty(registry.token))
+            if(registry.isValidCredential())
             {
-                credentialManager.SetCredential(registry.url, registry.auth, registry.token);
+                credentialManager.SetCredential(registry.Credential);
             }
             else
             {

--- a/Editor/Halodi/PackageRegistry/Core/ScopedRegistry.cs
+++ b/Editor/Halodi/PackageRegistry/Core/ScopedRegistry.cs
@@ -14,7 +14,18 @@ namespace Halodi.PackageRegistry.Core
         public bool auth;
 
         public string token;
+        public string _auth;
+        public string email;
 
+        public NPMCredential Credential => new NPMCredential()
+        {
+            url = url,
+            token = token,
+            _auth = _auth,
+            email = email,
+            alwaysAuth = auth
+        };
+        
         public override string ToString()
         {
             return JsonUtility.ToJson(this, true);
@@ -31,7 +42,7 @@ namespace Halodi.PackageRegistry.Core
 
             if(auth)
             {
-                if(string.IsNullOrEmpty(token))
+                if(string.IsNullOrEmpty(token) && string.IsNullOrEmpty(_auth))
                 {
                     return false;
                 }

--- a/Editor/Halodi/PackageRegistry/UI/CredentialEditorView.cs
+++ b/Editor/Halodi/PackageRegistry/UI/CredentialEditorView.cs
@@ -45,6 +45,8 @@ namespace Halodi.PackageRegistry.UI
             this.registry.url = credential.url;
             this.registry.auth = credential.alwaysAuth;
             this.registry.token = credential.token;
+            this.registry._auth = credential._auth;
+            this.registry.email = credential.email;
 
             this.createNew = false;
             this.initialized = true;
@@ -73,18 +75,20 @@ namespace Halodi.PackageRegistry.UI
 
                 registry.auth = EditorGUILayout.Toggle("Always auth", registry.auth);
                 registry.token = EditorGUILayout.TextField("Token", registry.token);
+                registry._auth = EditorGUILayout.TextField("Basic Auth", registry._auth);
+                registry.email = EditorGUILayout.TextField("Email", registry.email);
 
                 EditorGUILayout.Space();
 
                 EditorGUI.BeginDisabledGroup(string.IsNullOrEmpty(registry.url));
                 tokenMethod = GetTokenView.CreateGUI(tokenMethod, registry);
                 
-                if (!string.IsNullOrEmpty(registry.url) && string.IsNullOrEmpty(registry.token))
+                if (!string.IsNullOrEmpty(registry.url) && string.IsNullOrEmpty(registry.token) && string.IsNullOrEmpty(registry._auth))
                 {
                     EditorGUILayout.HelpBox("Select an authentication method and click on \"Get token\"", MessageType.Warning);
                 }
                 
-                EditorGUI.BeginDisabledGroup(string.IsNullOrEmpty(registry.token));
+                EditorGUI.BeginDisabledGroup(string.IsNullOrEmpty(registry.token) && string.IsNullOrEmpty(registry._auth));
                 
                 EditorGUILayout.Space();
                 EditorGUILayout.BeginVertical(GUILayout.ExpandHeight(true));
@@ -121,9 +125,9 @@ namespace Halodi.PackageRegistry.UI
 
         private void Save()
         {
-            if (registry.isValidCredential() && !string.IsNullOrEmpty(registry.token))
+            if (registry.isValidCredential())
             {
-                credentialManager.SetCredential(registry.url, registry.auth, registry.token);
+                credentialManager.SetCredential(registry.Credential);
                 credentialManager.Write();
                 
                 // TODO figure out in which cases/Editor versions a restart is actually required,

--- a/Editor/Halodi/PackageRegistry/UI/RegistryManagerView.cs
+++ b/Editor/Halodi/PackageRegistry/UI/RegistryManagerView.cs
@@ -44,7 +44,7 @@ namespace Halodi.PackageRegistry.UI
                 {
                     var registry = registryList.list[index] as ScopedRegistry;
                     if (registry == null) return;
-                    bool registryHasAuth = !string.IsNullOrEmpty(registry.token) && registry.isValidCredential();
+                    bool registryHasAuth = registry.isValidCredential();
 
                     var rect2 = rect;
                     rect.width -= 60;

--- a/Editor/Halodi/PackageRegistry/UI/ScopedRegistryEditorView.cs
+++ b/Editor/Halodi/PackageRegistry/UI/ScopedRegistryEditorView.cs
@@ -99,6 +99,8 @@ namespace Halodi.PackageRegistry.UI
                 
                 registry.auth = EditorGUILayout.Toggle("Always auth", registry.auth);
                 registry.token = EditorGUILayout.TextField("Token", registry.token);
+                registry._auth = EditorGUILayout.TextField("Basic Auth", registry._auth);
+                registry.email = EditorGUILayout.TextField("Email", registry.email);
 
                 EditorGUILayout.Space();
 


### PR DESCRIPTION
Quick fix for #28 

I also added support for the email field. Works for me now, however, there might still be some edge cases where it breaks or some of the validation in the UI does not work correctly.

The UI simply shows all available fields:
![image](https://user-images.githubusercontent.com/11772241/144855950-be4cee98-8c21-49d8-a7d8-67d2ae79fcf6.png)