### PR TITLE
Updated package version to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.halodi.halodi-unity-package-registry-manager",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "displayName": "Halodi Package Registry Manager",
   "type": "tool",
   "samples": [],


### PR DESCRIPTION
Updated package version (forgot to do it in my previous PR) as this caused open upm build to not publish the new package version

![image](https://github.com/Halodi/halodi-unity-package-registry-manager/assets/61387365/6b5818fb-59ac-4465-b148-734fb50405ff)


Skipped version 1.0.4 to avoid issues with openupm.